### PR TITLE
fix(codeql): fix branch wildcard

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, * ]
+    branches: [ main, '*' ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]


### PR DESCRIPTION
* is a special character in YAML, so we must use quotes
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet