### PR TITLE
✨ don't hardcode Environment.OS

### DIFF
--- a/pkg/provenance.go
+++ b/pkg/provenance.go
@@ -162,7 +162,7 @@ func GenerateProvenance(name, digest, ghContext, command, envs string) ([]byte, 
 				},
 				// Non user-controllable environment vars needed to reproduce the build.
 				Environment: map[string]interface{}{
-					"arch":               "amd64", // TODO: Does GitHub run actually expose this?
+					"arch":               os.Getenv("RUNNER_ARCH"),
 					"os":                 os.Getenv("ImageOS"),
 					"github_event_name":  gh.EventName,
 					"github_run_number":  gh.RunNumber,

--- a/pkg/provenance.go
+++ b/pkg/provenance.go
@@ -199,6 +199,9 @@ func GenerateProvenance(name, digest, ghContext, command, envs string) ([]byte, 
 						"sha1": gh.SHA,
 					},
 				},
+				{
+					URI: fmt.Sprintf("https://github.com/actions/virtual-environments/releases/tag/%s/%s", os.Getenv("ImageOS"), os.Getenv("ImageVersion")),
+				},
 			},
 		},
 	}

--- a/pkg/provenance.go
+++ b/pkg/provenance.go
@@ -163,7 +163,7 @@ func GenerateProvenance(name, digest, ghContext, command, envs string) ([]byte, 
 				// Non user-controllable environment vars needed to reproduce the build.
 				Environment: map[string]interface{}{
 					"arch":               "amd64", // TODO: Does GitHub run actually expose this?
-					"os":                 "ubuntu",
+					"os":                 os.Getenv("ImageOS"),
 					"github_event_name":  gh.EventName,
 					"github_run_number":  gh.RunNumber,
 					"github_run_id":      gh.RunID,


### PR DESCRIPTION
Read the runner's OS and architecture from the environment variables set for GitHub Actions [virtual environments](https://github.com/actions/virtual-environments).
Store information about the virtual environment in the provenance's materials.
