### PR TITLE
✨ Add support for uploading assets

### DIFF
--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == 'true'
     steps:
-      - run:
+      - run: |
         exit 1
   ###################################################################
   #                                                                 #

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -468,9 +468,10 @@ jobs:
 
           # Compare hashes. Explicit exit to be safe.
           echo "$UNTRUSTED_PROVENANCE_HASH $UNTRUSTED_PROVENANCE_NAME" | sha256sum --strict --check --status || exit -2
+      
       - run: |
-        echo ${{ needs.build-dry.outputs.go-binary-name }}
-        echo ${{ needs.provenance.outputs.go-provenance-name }}
+          echo "${{ needs.build-dry.outputs.go-binary-name }}""
+          echo "${{ needs.provenance.outputs.go-provenance-name }}"
 
       - name: Release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -36,6 +36,11 @@ on:
         description: "The go version to use"
         required: true
         type: string
+      upload-assets:
+        description: "Whether to upload assets to a GitHub release or not"
+        required: false
+        type: boolean
+        default: true
       env:
         description: "Env variables to pass to the builder"
         required: false
@@ -360,6 +365,9 @@ jobs:
     permissions:
       id-token: write # Needed for keyless.
       contents: read
+    outputs:
+      go-provenance-name: ${{ steps.sign-prov.outputs.signed-provenance-name }}
+      go-provenance-sha256: ${{ steps.sign-prov.outputs.signed-provenance-sha256 }}
     steps:
       - name: Download builder
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v2.1.0
@@ -410,3 +418,60 @@ jobs:
           path: "${{ steps.sign-prov.outputs.signed-provenance-name }}"
           if-no-files-found: error
           retention-days: 5
+
+###################################################################
+#                                                                 #
+#           Upload binaries and provenances as assets             #
+#                                                                 #
+###################################################################
+  upload-assets:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: [build,build-dry,provenance]
+    steps:
+      # Verify binary hash.
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+        with:
+          name: ${{ needs.build-dry.outputs.go-binary-name }}
+      - name: Verify binary hash
+        env:
+          UNTRUSTED_BINARY_HASH: "${{ needs.build.outputs.go-binary-sha256 }}"
+          UNTRUSTED_BINARY_NAME: "${{ needs.build-dry.outputs.go-binary-name }}"
+        run: |
+          set -euo pipefail
+
+          echo "hash of binary $UNTRUSTED_BINARY_NAME should be $UNTRUSTED_BINARY_HASH"
+
+          COMPUTED_HASH=$(sha256sum "$UNTRUSTED_BINARY_NAME" | awk '{print $1}')
+          echo "binary hash computed is $COMPUTED_HASH"
+
+          # Compare hashes. Explicit exit to be safe.
+          echo "$UNTRUSTED_BINARY_HASH $UNTRUSTED_BINARY_NAME" | sha256sum --strict --check --status || exit -2
+
+      # Verify provenance hash.
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+        with:
+          name: ${{ needs.provenance.outputs.go-provenance-name }}
+      - name: Verify provenance hash
+        env:
+          UNTRUSTED_PROVENANCE_HASH: "${{ needs.provenance.outputs.go-provenance-sha256 }}"
+          UNTRUSTED_PROVENANCE_NAME: "${{ needs.provenance.outputs.go-provenance-name }}"
+        run: |
+          set -euo pipefail
+
+          echo "hash of provenance $UNTRUSTED_PROVENANCE_NAME should be $UNTRUSTED_PROVENANCE_HASH"
+
+          COMPUTED_HASH=$(sha256sum "$UNTRUSTED_PROVENANCE_NAME" | awk '{print $1}')
+          echo "provenance hash computed is $COMPUTED_HASH"
+
+          # Compare hashes. Explicit exit to be safe.
+          echo "$UNTRUSTED_PROVENANCE_HASH $UNTRUSTED_PROVENANCE_NAME" | sha256sum --strict --check --status || exit -2
+
+      - name: Release
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{ needs.build-dry.outputs.go-binary-name }}
+            ${{ needs.provenance.outputs.go-provenance-name }}

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -56,7 +56,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == 'true'
     steps:
       - run: |
-        exit 1
+          exit 1
+  
   ###################################################################
   #                                                                 #
   #                       Build the builder                         #

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -468,10 +468,6 @@ jobs:
 
           # Compare hashes. Explicit exit to be safe.
           echo "$UNTRUSTED_PROVENANCE_HASH $UNTRUSTED_PROVENANCE_NAME" | sha256sum --strict --check --status || exit -2
-      
-      - run: |
-          echo "${{ needs.build-dry.outputs.go-binary-name }}"
-          echo "${{ needs.provenance.outputs.go-provenance-name }}"
 
       - name: Release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -51,6 +51,12 @@ on:
         value: ${{ jobs.build-dry.outputs.go-binary-name }}
 
 jobs:
+  test-bool:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == 'true'
+    steps:
+      - run:
+        exit 1
   ###################################################################
   #                                                                 #
   #                       Build the builder                         #

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -429,7 +429,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     needs: [build,build-dry,provenance]
-    if: if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
+    if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
     steps:
       # Verify binary hash.
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -470,7 +470,7 @@ jobs:
           echo "$UNTRUSTED_PROVENANCE_HASH $UNTRUSTED_PROVENANCE_NAME" | sha256sum --strict --check --status || exit -2
       
       - run: |
-          echo "${{ needs.build-dry.outputs.go-binary-name }}""
+          echo "${{ needs.build-dry.outputs.go-binary-name }}"
           echo "${{ needs.provenance.outputs.go-provenance-name }}"
 
       - name: Release

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -53,9 +53,18 @@ on:
 jobs:
   test-bool:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == 'true'
+    if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
     steps:
       - run: |
+          echo happens if release is on
+          exit 1
+  test-bool2:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets != true
+    steps:
+      - run: |
+          echo happens if release is off
+          exit 1
           exit 1
   
   ###################################################################

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -429,6 +429,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     needs: [build,build-dry,provenance]
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       # Verify binary hash.
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
@@ -470,7 +471,6 @@ jobs:
 
       - name: Release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             ${{ needs.build-dry.outputs.go-binary-name }}

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -51,22 +51,6 @@ on:
         value: ${{ jobs.build-dry.outputs.go-binary-name }}
 
 jobs:
-  test-bool:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
-    steps:
-      - run: |
-          echo happens if release is on
-          exit 1
-  test-bool2:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets != true
-    steps:
-      - run: |
-          echo happens if release is off
-          exit 1
-          exit 1
-  
   ###################################################################
   #                                                                 #
   #                       Build the builder                         #
@@ -445,7 +429,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     needs: [build,build-dry,provenance]
-    if: startsWith(github.ref, 'refs/tags/') && ${{ inputs.upload-assets == 'true' }}
+    if: if: startsWith(github.ref, 'refs/tags/') && inputs.upload-assets == true
     steps:
       # Verify binary hash.
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -429,7 +429,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     needs: [build,build-dry,provenance]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && ${{ inputs.upload-assets == 'true' }}
     steps:
       # Verify binary hash.
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -468,6 +468,9 @@ jobs:
 
           # Compare hashes. Explicit exit to be safe.
           echo "$UNTRUSTED_PROVENANCE_HASH $UNTRUSTED_PROVENANCE_NAME" | sha256sum --strict --check --status || exit -2
+      - run: |
+        echo ${{ needs.build-dry.outputs.go-binary-name }}
+        echo ${{ needs.provenance.outputs.go-provenance-name }}
 
       - name: Release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/in-toto/in-toto-golang v0.3.4-0.20211211042327-af1f9fb822bf
+	github.com/sigstore/cosign v1.6.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
@@ -211,7 +212,6 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.3.1 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
-	github.com/sigstore/cosign v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220213190939-1e6e3497d506 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect


### PR DESCRIPTION
Upload the provenance and the binary as assets to the release, when the workflow runs on a push with new tag.
closes https://github.com/slsa-framework/slsa-github-generator-go/issues/58