### PR TITLE
Change example to content:write permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ jobs:
   build:
     permissions:
       id-token: write
-      contents: read
+      contents: write
     needs: args
     uses: slsa-framework/slsa-github-generator-go/.github/workflows/slsa3_builder.yml@main # TODO: use hash upon release.
     with:


### PR DESCRIPTION
Ran into error while trying to use this on a repo, seems like permission requirement has changed.

`
The workflow is not valid. .github/workflows/slsa-goreleaser.yaml (Line: 27, Col: 3): Error calling workflow 'slsa-framework/slsa-github-generator-go/.github/workflows/slsa3_builder.yml@main'. The nested job 'upload-assets' is requesting 'contents: write', but is only allowed 'contents: read'.
`