### PR TITLE
✨ Option to pass config path

### DIFF
--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: boolean
         default: true
+      config-file:
+        description: "The configuration file defining the builds"
+        required: false
+        type: string
+        default: "${{ env.RELEASER_CONFIG }}"
       env:
         description: "Env variables to pass to the builder"
         required: false
@@ -202,7 +207,7 @@ jobs:
         shell: bash
         env:
           BUILDER_BINARY: "${{ env.BUILDER_BINARY }}"
-          CONFIG_FILE: "${{ env.RELEASER_CONFIG }}"
+          CONFIG_FILE: "${{ inputs.upload-assets }}"
           UNTRUSTED_ENVS: "${{ inputs.env }}"
           UNTRUSTED_WORKING_DIR: "${{ inputs.working-dir }}"
         run: |
@@ -278,7 +283,7 @@ jobs:
         shell: bash
         env:
           BUILDER_BINARY: "${{ env.BUILDER_BINARY }}"
-          CONFIG_FILE: "${{ env.RELEASER_CONFIG }}"
+          CONFIG_FILE: "${{ inputs.upload-assets }}"
           UNTRUSTED_ENVS: "${{ inputs.env }}"
           UNTRUSTED_WORKING_DIR: "${{ inputs.working-dir }}"
         run: |

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -206,7 +206,7 @@ jobs:
         shell: bash
         env:
           BUILDER_BINARY: "${{ env.BUILDER_BINARY }}"
-          CONFIG_FILE: "${{ inputs.upload-assets }}"
+          CONFIG_FILE: "${{ inputs.config-file }}"
           UNTRUSTED_ENVS: "${{ inputs.env }}"
           UNTRUSTED_WORKING_DIR: "${{ inputs.working-dir }}"
         run: |
@@ -282,7 +282,7 @@ jobs:
         shell: bash
         env:
           BUILDER_BINARY: "${{ env.BUILDER_BINARY }}"
-          CONFIG_FILE: "${{ inputs.upload-assets }}"
+          CONFIG_FILE: "${{ inputs.config-file }}"
           UNTRUSTED_ENVS: "${{ inputs.env }}"
           UNTRUSTED_WORKING_DIR: "${{ inputs.working-dir }}"
         run: |

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -41,7 +41,7 @@ on:
         type: boolean
         default: true
       config-file:
-        description: "The configuration file defining the builds"
+        description: "The configuration file for the builder. A path within the calling repository."
         required: false
         type: string
         default: ".slsa-goreleaser.yml"

--- a/.github/workflows/slsa3_builder.yml
+++ b/.github/workflows/slsa3_builder.yml
@@ -19,7 +19,6 @@ permissions:
 
 env:
   # Project.
-  RELEASER_CONFIG: .slsa-goreleaser.yml
   GENERATED_BINARY_NAME: compiled-binary
   # Builder
   BUILDER_BINARY: builder
@@ -45,7 +44,7 @@ on:
         description: "The configuration file defining the builds"
         required: false
         type: string
-        default: "${{ env.RELEASER_CONFIG }}"
+        default: ".slsa-goreleaser.yml"
       env:
         description: "Env variables to pass to the builder"
         required: false

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -49,6 +49,11 @@ func Test_ConfigFromFile(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name:     "valid releaser main with parent path",
+			path:     "../pkg/testdata/releaser-valid-main.yml",
+			expected: nil,
+		},
+		{
 			name:     "missing version",
 			path:     "./testdata/releaser-noversion.yml",
 			expected: errorUnsupportedVersion,
@@ -66,6 +71,11 @@ func Test_ConfigFromFile(t *testing.T) {
 		{
 			name:     "invalid main",
 			path:     "./testdata/releaser-invalid-main.yml",
+			expected: errorInvalidDirectory,
+		},
+		{
+			name:     "invalid path",
+			path:     "../testdata/releaser-invalid-main.yml",
 			expected: errorInvalidDirectory,
 		},
 	}

--- a/pkg/files.go
+++ b/pkg/files.go
@@ -1,0 +1,41 @@
+// Copyright 2022 SLSA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var errorInvalidDirectory = errors.New("invalid directory")
+
+func isUnderWD(path string) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	p, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(p, wd+"/") {
+		return errorInvalidDirectory
+	}
+
+	return nil
+}

--- a/pkg/files_test.go
+++ b/pkg/files_test.go
@@ -1,0 +1,63 @@
+// Copyright 2022 SLSA Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_isUnderWD(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected error
+	}{
+		{
+			name:     "some valid path",
+			path:     "./some/valid/path",
+			expected: nil,
+		},
+		{
+			name:     "some valid path",
+			path:     "../pkg/some/valid/path",
+			expected: nil,
+		},
+		{
+			name:     "parent invalid path",
+			path:     "../invalid/path",
+			expected: errorInvalidDirectory,
+		},
+		{
+			name:     "some invalid fullpath",
+			path:     "/some/invalid/fullpath",
+			expected: errorInvalidDirectory,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := isUnderWD(tt.path)
+			if !errCmp(err, tt.expected) {
+				t.Errorf(cmp.Diff(err, tt.expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
We currently assume the location of the config file is `.slsa-goreleaser.yml`.
This PR lets users pass an optional config file pass. The default remains `.slsa-goreleaser.yml`.

closes https://github.com/slsa-framework/slsa-github-generator-go/issues/72