### PR TITLE
fix: re-include runner virt env image in materials

### DIFF
--- a/pkg/provenance.go
+++ b/pkg/provenance.go
@@ -119,6 +119,13 @@ func GenerateProvenance(name, digest, command, envs string) ([]byte, error) {
 	invEnv["arch"] = os.Getenv("RUNNER_ARCH")
 	invEnv["os"] = os.Getenv("ImageOS")
 
+	// Add details about the runner's OS to the materials
+	runnerMaterials := slsa02.ProvenanceMaterial{
+		// TODO: capture the digest here too
+		URI: fmt.Sprintf("https://github.com/actions/virtual-environments/releases/tag/%s/%s", os.Getenv("ImageOS"), os.Getenv("ImageVersion")),
+	}
+	p.Predicate.Materials = append(p.Predicate.Materials, runnerMaterials)
+
 	// Sign the provenance.
 	s := sigstore.NewDefaultSigner()
 	att, err := s.Sign(ctx, p)


### PR DESCRIPTION
The port to the generic library in #57 removed the change from #16 to:

"List the virtual environment used by the GitHub Actions runner as a
material in the provenance metadata."

Restore that functionality.