### PR TITLE
chore: list new inputs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ The builder workflow [slsa-framework/slsa-github-generator-go/.github/workflows/
 
 | Name         | Required | Description                                                                                                                                                                                                                                               |
 | ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `go-version` | yes      | The go version for your project. This value is passed, unchanged, to the [actions/setup-go](https://github.com/actions/setup-go) action when setting up the environment                                                                                   |
+| `config-file` | no      | The configuration file for the builder. A path within the calling repository. |
 | `evaluated-envs`        | no       | A list of environment variables, seperated by `,`: `VAR1: value, VAR2: value`. This is typically used to pass dynamically-generated values, such as `ldflags`. Note that only environment variables with names starting with `CGO_` or `GO` are accepted. |
+| `go-version` | yes      | The go version for your project. This value is passed, unchanged, to the [actions/setup-go](https://github.com/actions/setup-go) action when setting up the environment |
+| `upload-assets` | no    | Whether to upload assets to a GitHub release or not. |
 
 ### Workflow Example
 


### PR DESCRIPTION
Add recently introduced workflow inputs to the README.
Sort the table alphabetically by input name.